### PR TITLE
CI: super-linter - disable trivy and zizmor

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_TRIVY: false
   shiftleft:
     name: shiftleft
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

Disable Trivy and Zizmor validations in the super-linter CI workflow

CI:
- Disable VALIDATE_TRIVY by setting it to false in the docker.image workflow
- Disable VALIDATE_GITHUB_ACTIONS_ZIZMOR by setting it to false in the docker.image workflow